### PR TITLE
Changed Kivy version in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install kivymd_extensions.sweetalert
 ### Dependencies:
 
 - [KivyMD](https://github.com/kivymd/KivyMD) >= 0.104.2 (currently master branch)
-- [Kivy](https://github.com/kivy/kivy) >= 1.10.1 ([Installation](https://kivy.org/doc/stable/gettingstarted/installation.html))
+- [Kivy](https://github.com/kivy/kivy) >= 2.0.0 ([Installation](https://kivy.org/doc/stable/gettingstarted/installation.html))
 - [Python 3.6+](https://www.python.org/)
 
 ## Documentation


### PR DESCRIPTION
As KivyMD no longer supports Kivy 1.x.x, I updated it to 2.0.0.

### Changes

Changed version of Kivy. Nothing more.