### PR TITLE
modified the location of the 'FitImage' class

### DIFF
--- a/kivymd_extensions/sweetalert/sweetalert.py
+++ b/kivymd_extensions/sweetalert/sweetalert.py
@@ -59,7 +59,7 @@ from kivymd.uix.dialog import MDDialog
 from kivymd.uix.label import MDLabel
 from kivymd.uix.spinner import MDSpinner
 from kivymd.uix.textfield import MDTextFieldRect
-from kivymd.utils.fitimage import FitImage
+from kivymd.uix.fitimage import FitImage
 
 from kivymd_extensions.sweetalert.animation import FailureAnimation, OthersAnimation, SuccessAnimation
 


### PR DESCRIPTION
### Changes made
* changed the location of the fitimage.py module in the import from `kivymd.utils.fitimage` to `kivymd.uix.fitimage` 

### Explanation of changes
In the latest kivymd version (1.0.2) the fitimage.py module(containing the FitImage class), was moved from kivymd.utils to kivymd.uix!


